### PR TITLE
Les types isize et usize ne sont pas l'équivalent de int et de unsigned int en C/C++.

### DIFF
--- a/Rust/1_4.md
+++ b/Rust/1_4.md
@@ -49,7 +49,7 @@ Donc pour résumer, voici une petite liste des différents types de base disponi
  * f64 : un nombre flottant de 64 bits
  * String
 
-Sachez cependant que les types __isize__ et __usize__ existent aussi et sont l'équivalent de __int__ et de __unsigned int__ en C/C++. En gros, sur un système 32 bits, ils feront respectivement 32 bits tandis qu'ils feront 64 bits sur un système 64 bits.
+Sachez cependant que les types __isize__ et __usize__ existent aussi et sont l'équivalent de __intptr_t__ et de __uintptr_t__ en C/C++. En gros, sur un système 32 bits, ils feront respectivement 32 bits tandis qu'ils feront 64 bits sur un système 64 bits.
 
 Dernier petit point à aborder : il est courant de croiser ce genre de code en C/C++/Java/etc... :
 


### PR DESCRIPTION
`isize` et `usize` ont la taille de pointeurs donc ils sont l'équivalent de `intptr_t` et de `uintptr_t`.