### PR TITLE
Corrige la faute sur la memoire "tas" ainsi que quelques propositions

### DIFF
--- a/src/2_12.md
+++ b/src/2_12.md
@@ -3,7 +3,7 @@
 
 Le type [Box](https://doc.rust-lang.org/stable/std/boxed/struct.Box.html) est "tout simplement" un pointeur sur des données stockées "sur le tas" (dans la mémoire heap donc).
 
-On s'en sert notamment quand on veut éviter de trop surcharger la pile (la mémoire stack) en instanciant directement sur la pile (la mémoire heap). Par-contre, la feature le permettant est encore instable donc le code suivant ne fonctionnera pas si vous utilisez la version stable du compilateur :
+On s'en sert notamment quand on veut éviter de trop surcharger la pile (la mémoire stack) en instanciant directement sur le tas (la mémoire heap). Par-contre, la feature le permettant est encore instable donc le code suivant ne fonctionnera pas si vous utilisez la version stable du compilateur :
 
 ```Rust
 #![feature(box_syntax)]
@@ -18,7 +18,7 @@ Pour mieux illustrer ce qu'est le type [Box](https://doc.rust-lang.org/stable/st
 
 ###Structure récursive
 
-On s'en sert aussi dans le cas de figure où on ne sait pas quelle taille fera le type, comme les types récursifs par exemple :
+On s'en sert aussi dans le cas où on ignore quelle taille fera le type, comme les types récursifs par exemple :
 
 ```Rust
 #[derive(Debug)]
@@ -33,7 +33,7 @@ fn main() {
 }
 ```
 
-Si vous essayez de compiler ce code, vous obtiendrez une magnifique erreur : "invalid recursive enum type". (Le problème sera exactement le même si on utilise une structure). Ce type n'a pas de taille défini, nous obligeant à utiliser un type qui lui en a une (donc `&` ou bien `Box`) :
+Si vous essayez de compiler ce code, vous obtiendrez une magnifique erreur : "invalid recursive enum type". (Notez que le problème sera le même si on utilise une structure). Ce type n'a pas de taille défini, nous obligeant à utiliser un type, qui lui, en a une (donc `&` ou bien `Box`) :
 
 ```Rust
 #[derive(Debug)]
@@ -50,7 +50,7 @@ fn main() {
 
 ###Liste chaînée
 
-Un autre cas de figure où [Box](https://doc.rust-lang.org/stable/std/boxed/struct.Box.html) est utile à utiliser est pour la création de listes chaînées :
+[Box](https://doc.rust-lang.org/stable/std/boxed/struct.Box.html) est également utile pour la création de listes chaînées :
 
 ```Rust
 use std::fmt::Display;


### PR DESCRIPTION
Hello et merci pour ton tuto, le seul en français.

Ayant remarque une erreur dans la répétition du terme "pile", j'ai voulu faire un correctif.

Je te propose aussi quelques modifications (et pourquoi pas, la discussion qui l'accompagne).\

D'une manière générale, je trouve les phrases très lourdes dans le tuto. On dirait parfois une traduction direct. Je suis tout a fait d'accords qu'il ne faut pas céder a la simplification extrême des phrases qui font perde toute nuance au propos. Je pense toutefois que les termes choisis n’apportent pas nécessairement de nuance mais retire la fluidité de la lecture.

Il s'agit, bien entendu, d'une remarque personnelle.