### PR TITLE
Ajout des termes techniques anglais

### DIFF
--- a/src/1_1.md
+++ b/src/1_1.md
@@ -4,7 +4,7 @@
 Rust est un langage de programmation système, compilé et [multi-paradigme](https://fr.wikipedia.org/wiki/Paradigme_(programmation)). C'est un croisement entre langage impératif (C), objet (C++), fonctionnel (Ocaml) et concurrent (Erlang). Il s'inspire des recherches en théories des langages de ces dernières années et des langages de programmation les plus populaires afin d'atteindre trois objectifs : rapidité, sécurité (en mémoire notamment) et concurrent (partage des données sécurisé entre tâches).
 
 Le développement du langage, [initié par Graydon Hoare](https://www.reddit.com/r/rust/comments/27jvdt/internet_archaeology_the_definitive_endall_source/), est opéré depuis 2009 par la fondation Mozilla, ainsi que par la communauté des développeurs Rust très présente sur Github. Pour suivre ce tutoriel, il est fortement recommandé d'avoir déjà développé dans au moins un autre langage (C, C++, java, javascript, python, etc...) car je ne passerai que très brièvement sur les bases. Ses points forts sont :
- * La gestion de "propriété" des variables
+ * La gestion de "propriété" (ownership) des variables
  * La gestion de la mémoire
  * Le typage statique
  * L'inférence de type

--- a/src/1_11.md
+++ b/src/1_11.md
@@ -124,7 +124,7 @@ Et enfin les symboles d'(in)égalité permettent :
 
 Il est possible de mettre plusieurs exigences en les séparant avec une virgule : ``>= 1.2, < 1.5.``.
 
-Maintenant regardons comment ajouter une dépendance à une bibliothèque qui n'est pas sur crates.io (ou qui y est mais pour une raison ou pour une autre, vous ne voulez pas passer par elle) :
+Maintenant regardons comment ajouter une dépendance à une bibliothèque qui n'est pas sur [crates.io](https://crates.io/) (ou qui y est mais pour une raison ou pour une autre, vous ne voulez pas passer par elle) :
 
 ```Toml
 [package]

--- a/src/2_5.md
+++ b/src/2_5.md
@@ -1,5 +1,5 @@
 #Spécificités de Rust
-##Propriété
+##Propriété (ou ownership)
 
 Jusqu'à présent, de temps à autres, on utilisait le caractère '&' devant des paramètres de fonctions sans que je vous explique à quoi ça servait. Exemple :
 

--- a/src/2_6.md
+++ b/src/2_6.md
@@ -1,7 +1,7 @@
 #Spécificités de Rust
-##Durée de vie
+##Durée de vie (ou lifetime)
 
-Il existe plusieurs types de durée de vie (ou lifetime). Jusqu'à présent, nous n'avons vu que les plus basique mais sachez qu'il en existe encore deux autres :
+Il existe plusieurs types de durée de vie. Jusqu'à présent, nous n'avons vu que les plus basique mais sachez qu'il en existe encore deux autres :
 
  * Les durées de vie statiques.
  * Les durées de vie associées.

--- a/src/3_1.md
+++ b/src/3_1.md
@@ -1,5 +1,5 @@
 #Aller plus loin
-##Utiliser du code compilé en C
+##Utiliser du code compilé en C (FFI, [Foreign Function Interface](https://en.wikipedia.org/wiki/Foreign_function_interface))
 
 Rust permet d'exécuter du code compilé en C. Ce chapitre va vous montrer comment faire.
 


### PR DESCRIPTION
(Navré pour le doublon de #41, git n'est pas aussi intuitif sous Windows que sous Linux, l'historique a tout de même a été nettoyé)
Je me suis permis de modifier le header de la section `Durée de vie` pour rester cohérent avec les modifications appliquées au header `Propriété`.

Fixes #20.