### PR TITLE
Import crate rand in example

### DIFF
--- a/src/1_13.md
+++ b/src/1_13.md
@@ -28,9 +28,12 @@ Vous avez gagné !
 Bonne question ! On va utiliser la bibliothèque externe [rand](https://crates.io/crates/rand). Ajoutez-la comme dépendance dans votre fichier __Cargo.toml__ et ensuite importez-la dans votre fichier principal. Maintenant, pour générer un nombre il vous suffira de faire :
 
 ```Rust
+extern crate rand;
 use rand::Rng;
 
-let nombre_aleatoire = rand::thread_rng().gen_range(1, 101);
+fn main() {
+    let nombre_aleatoire = rand::thread_rng().gen_range(1, 101);
+}
 ```
 
 Il va aussi falloir récupérer ce que l'utilisateur écrit sur le clavier. Pour cela, utilisez la méthode [read_line](https://doc.rust-lang.org/stable/std/io/struct.Stdin.html#method.read_line) de l'objet [Stdin](https://doc.rust-lang.org/stable/std/io/struct.Stdin.html) (qu'on peut récupérer avec la fonction [stdin](https://doc.rust-lang.org/stable/std/io/fn.stdin.html)). Il ne vous restera plus qu'à convertir cette [String](https://doc.rust-lang.org/stable/std/string/struct.String.html) en entier en utilisant la méthode [from_str](https://doc.rust-lang.org/stable/std/str/trait.FromStr.html#tymethod.from_str). Je pense vous avoir donné assez d'indications pour que vous puissiez vous débrouiller seuls. Bon courage !


### PR DESCRIPTION
In the first example, after explaining how to import a crate, I propose to give a real example of how to import, and to use, an external crate (or library).

With those modifications, when we are running the code in the playground, we can now run a fully example (that works).