### PR TITLE
Suppression d'ambiguïté

### DIFF
--- a/src/1_4.md
+++ b/src/1_4.md
@@ -97,10 +97,10 @@ let mut v: Vec<u8> = Vec::new();
 v.push(0);
 v.push(1);
 v.push(2);
-let s = &v;
-println!("{:?}", s); // ça affichera "[0, 1, 2]"
-let s = &v[1..];
-println!("{:?}", s); // ça affichera "[1, 2]"
+let s_one = &v;
+println!("{:?}", s_one); // ça affichera "[0, 1, 2]"
+let s_two = &v[1..];
+println!("{:?}", s_two); // ça affichera "[1, 2]"
 ```
 
 Les types contenant des tableaux ont toujours une [slice](https://doc.rust-lang.org/stable/std/primitive.slice.html) associée. Par-exemple, [String](https://doc.rust-lang.org/stable/std/string/struct.String.html) a [&str](https://doc.rust-lang.org/stable/std/primitive.str.html), [OsString](https://doc.rust-lang.org/stable/std/ffi/struct.OsString.html) a [OsStr](https://doc.rust-lang.org/stable/std/ffi/struct.OsStr.html), etc...


### PR DESCRIPTION
Work in progress

`src/1_4.md` : 
Objectif : Suppression de l'ambiguïté concernant la création de deux variables avec le même nom dans le même scope.
Explication : C'est intéressant car je me suis posé la question pour comprendre cette subtilité en Rust, qui n'est pas possible en Javascript, langage d'où je proviens. Du coup, je ne sais pas si le chapitre est approprié pour que le lecteur (débutant sur Rust logiquement) se pose cette question.