### PR TITLE
1_10.md: dernier exemple ne compile pas

### DIFF
--- a/src/1_10.md
+++ b/src/1_10.md
@@ -177,7 +177,7 @@ use std::fs::File;
 
 fn foo() -> Result<u32, String> {
     let mut fichier = File::open("fichier.txt")
-        .map_err(|e| println!("open error {:?}", e))?; // On change io::Error en String
+        .map_err(|e| format!("open error {:?}", e))?; // On change io::Error en String
     // ...
     Ok(0)
 }


### PR DESCRIPTION
Bonjour !
Dans le dernier exemple du chapitre 10 de la partie 1, le code ne compile pas ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=5624a0d5a20005a8079f54c2db61766f))
Je pense que la volonté était d'écrire `format!` à la place de `println!`.