### PR TITLE
Correctif sur l'exemple de la structure tuple

### DIFF
--- a/src/1_10.md
+++ b/src/1_10.md
@@ -74,7 +74,7 @@ let distance1 = Distance(2000);
 let distance2 = Distance(2000);
 
 // On peut récuperer la valeur contenue dans le type de cette façon.
-let Distance(longueur) = distance;
+let Distance(longueur) = distance2;
 println!(
     "La distance est {}m (ou {} km)",
     longueur,


### PR DESCRIPTION
Je ne comprenais pas et le playground m'a confirmé que c'était incorrect.

Note (pas un bug) : En tant que débutant, j'aurais mieux compris si la longueur sur `distance1` était différente de `distance2` car là ça retourne 2000 dans les deux cas ce qui ne montre pas trop la pertinence de définir deux distances.