### PR TITLE
Pertinence d'un exemple : conversion en kilomètres

### DIFF
--- a/src/1_10.md
+++ b/src/1_10.md
@@ -198,7 +198,7 @@ mod fichier;
 fn main() {
     let d = fichier::Distance::new();
     // ou
-    let d = fichier::Distance::new_with_value(10);
+    let d = fichier::Distance::new_with_value(10000);
 
     println!("distance en kilometres : {}", d.convert_in_kilometers());
 }


### PR DESCRIPTION
Dans la redéfinition de `d` avec 10 mètres, on va avoir un `convert_in_kilometers()` qui renvoie `0` dans le playground, c'est plus parlant de mettre `10000` pour que la sortie soit égale à `10`.