### PR TITLE
Fix typo d'url

### DIFF
--- a/src/2_11.md
+++ b/src/2_11.md
@@ -248,7 +248,7 @@ En bonus, je vous donne une petite liste de macros qui pourraient vous être uti
 
 ### Petite macro mais grande économie de lignes !
 
-Pour clôturer ce chapitre, je vous propose le code suivant qui permet d'améliorer celui présenté dans le [chapitre sur la généricité](https://blog.guillaume-gomez.fr/Rust/2/4) grâce à une macro :
+Pour clôturer ce chapitre, je vous propose le code suivant qui permet d'améliorer celui présenté dans le [chapitre sur la généricité](https://blog.guillaume-gomez.fr/Rust/2/3) grâce à une macro :
 
 ```Rust
 macro_rules! creer_animal {


### PR DESCRIPTION
/2/4 pointe sur la propriété, alors que /2/3 pointe sur la généricité