### PR TITLE
Amélioration du chapitre sur le pattern matching

### DIFF
--- a/src/1_5.md
+++ b/src/1_5.md
@@ -18,7 +18,7 @@ if age >= 18 {
 }
 ```
 
-Vous aurez noté que je n'ai pas mis de parenthèses, `(` et `)`, autour des conditions : elles sont superflues en Rust. Cependant, elles seront nécessaires si vous faites des "sous"-conditions :
+Notez que je n'ai pas mis de parenthèses, `(` et `)`, autour des conditions : elles sont superflues en Rust. Cependant, elles seront nécessaires si vous faites des "sous"-conditions :
 
 ```Rust
 if age > 18 && (age == 20 || age == 24) {
@@ -58,42 +58,53 @@ Regardons un exemple pour faciliter les explications :
 let my_string = "hello";
 
 match my_string {
-    "bonjour" => {
-        println!("français");
-    }
-    "ciao" => {
-        println!("italien");
-    }
-    "hello" => {
-        println!("anglais");
-    }
-    "hola" => {
-        println!("espagnol");
-    }
-    _ => {
-        println!("je ne connais pas cette langue...");
-    }
+    "bonjour" => println!("français"),
+    "ciao" => println!("italien"),
+    "hello" => println!("anglais"),
+    "hola" => println!("espagnol"),
+    _ => println!("je ne connais pas cette langue..."),
 }
 ```
 
 Ici ça affichera "anglais".
 
-Comme vous vous en doutez, on peut s'en servir sur n'importe quel type de variable. Après tout, il sert à comparer des __expressions__, vous pouvez très bien matcher sur un [__i32__](https://doc.rust-lang.org/stable/std/primitive.i32.html) ou un [__f64__](https://doc.rust-lang.org/stable/std/primitive.f64.html) si vous en avez besoin.
+On peut s'en servir sur n'importe quel type. Après tout, il sert à comparer avec des __patterns__ (__motifs__ en français). Vous pouvez très bien matcher sur un [__i32__](https://doc.rust-lang.org/stable/std/primitive.i32.html) ou sur un [__f64__](https://doc.rust-lang.org/stable/std/primitive.f64.html) si vous voulez.
 
-Concernant le ``_`` utilisé dans la dernière branche du __match__, il s'agit d'une variable (nommée ainsi pour éviter un warning pour variable non utilisée, ``_a`` aurait eu le même résultat) qui contient "toutes les autres expressions". C'est en quelque sorte le __else__ du pattern matching (il fonctionne de la même manière que le __default__ d'un switch C/C++/Java). Il est obligatoire de l'utiliser si toutes les expressions possibles n'ont pas été testées ! Dans le cas présent, il est impossible de tester toutes les strings existantes, on utilise donc ``_`` à la fin. Si on teste un booléen, il n'y aura que deux valeurs possibles et il sera possible de les tester toutes les deux :
+Concernant le ``_`` utilisé dans la dernière branche du __match__, il s'agit d'une variable (nommée ainsi pour éviter un warning pour variable non utilisée, ``_a`` aurait eu le même résultat) qui contient "tous les autres patterns". C'est en quelque sorte le __else__ du pattern matching. Il est obligatoire de l'utiliser si tous les patterns possibles n'ont pas été testés ! Dans le cas présent, il est impossible de tester toutes les strings existantes, on utilise donc ``_`` à la fin. Si on teste un booléen, il n'y aura que deux valeurs possibles et il sera possible de les tester toutes les deux :
 
 ```Rust
 let b = true;
 
 match b {
-    true => {
-        // faire quelque chose
-    }
-    false => {
-        // faire autre chose
-    }
+    true => println!("true"),
+    false => println!("false"),
 }
 ```
+
+La syntaxe du pattern matching suit ce modèle :
+
+```text
+pattern => expression,
+```
+
+Le ``=>`` sert à séparer le pattern de l'expression. La virgule sert à marquer la fin de l'expression.
+
+Si vous souhaitez faire plus d'une chose dans une branche du pattern matching, on peut ajouter des accolades :
+
+```Rust
+let b = true;
+let mut x = 0;
+
+match b {
+    true => {
+        println!("true");
+        x += 1;
+    }
+    false => println!("false"),
+}
+```
+
+Si vous utilisez des accolades, la virgule devient optionnelle (c'est pourquoi elle n'est en pratique jamais présente dans ce cas).
 
 Un autre exemple en utilisant un [__i32__](https://doc.rust-lang.org/stable/std/primitive.i32.html) :
 
@@ -142,11 +153,9 @@ let i = 0i32;
 
 match i {
     10..=100 => println!("La variable est entre 10 et 100 (inclus)"),
-    x => println!("{} n'est pas entre 10 et 100 (inclus)", x)
-};
+    x => println!("{} n'est pas entre 10 et 100 (inclus)", x),
+}
 ```
-
-À noter, dans le cas d’un ```for i in 10..100 { println!("{}", i); }```, __i__ prendra une valeur allant de 10 à 99 inclus.
 
 Vous pouvez aussi "binder" (ou matcher sur un ensemble de valeurs) la variable avec le symbole "@" :
 
@@ -155,8 +164,8 @@ let i = 0i32;
 
 match i {
     x @ 10..=100 => println!("{} est entre 10 et 100 (inclus)", x),
-    x => println!("{} n'est pas entre 10 et 100 (inclus)", x)
-};
+    x => println!("{} n'est pas entre 10 et 100 (inclus)", x),
+}
 ```
 
 Cela permet de stocker la valeur sur laquelle on matche directement dans `x`, ce qui est pratique si vous avez besoin de cette valeur (pour l'afficher comme dans le code au-dessus par-exemple).


### PR DESCRIPTION
Fixes #159.

Je ne parle volontairement pas du fait que la dernière virgule est optionnelle parce que rustfmt la met à chaque fois. J'ai aussi supprimer le point après les `match`. Ce point est abordé dans le chapitre suivant donc autant faciliter la transition.